### PR TITLE
Allow attachments to created in a subfolder

### DIFF
--- a/backend/dropbox_client.py
+++ b/backend/dropbox_client.py
@@ -7,24 +7,35 @@ class MailmanClient():
             oauth2_access_token="temp_token"
         )
 
-    def upload_file_to_dropbox(self, email_contents, path, desired_file_name, access_token):
-        content_in_bytes = self.convert_email_content_to_bytes(email_contents)
-        path = "%s/%s" % (path, desired_file_name)
+    def upload_file_to_dropbox(self, file_contents, path, file_name, access_token):
+        if not type(file_contents) is bytes:
+            file_contents = self.convert_file_content_to_bytes(file_contents)
+        path = "%s/%s" % (path, file_name)
 
         self.reset_tokens(access_token)
         self.dbx.files_upload(
-            content_in_bytes, 
+            file_contents, 
             path, 
             mode=files.WriteMode.overwrite,  # when saving over a previous email/thread, overrides the file
             strict_conflict=False
             )
         
 
-    def convert_email_content_to_bytes(self, email_contents):
-        return email_contents.encode('ascii')
+    def convert_file_content_to_bytes(self, file_contents):
+        return file_contents.encode('ascii')
 
     def reset_tokens(self, access_token):
         dbx = self.dbx
         dbx._oauth2_access_token = access_token
         dbx._oauth2_refresh_token = None
         dbx._oauth2_access_token_expiration = None
+
+    def upload_email(self, message_obj, path, access_token):
+        if message_obj.attachments:
+            attachments_path = "%s/attachments" % path
+            for attachment in message_obj.attachments:
+                file_name = attachments.filename
+                file_contents = attachments.payload
+                self.upload_file_to_dropbox(file_contents, attachments_path, file_name, access_token)
+
+        self.upload_file_to_dropbox(message_obj.text, path, message_obj.subject, access_token)


### PR DESCRIPTION
Allowing attachments to also be uploaded. Please leave a comment if I am accessing the message object incorrectly. Essentially, now we would call `upload_email` instead of the other method and it would handle the logic if it was a standalone email or one with attachments.